### PR TITLE
Allow use in init_worker_by_lua

### DIFF
--- a/lib/resty/mongol/object_id.lua
+++ b/lib/resty/mongol/object_id.lua
@@ -55,7 +55,7 @@ else
 end
 machineid = ngx.md5_bin(machineid):sub(1, 3)
 
-local pid = num_to_le_uint(bit.band(ngx.var.pid, 0xFFFF), 2)
+local pid = num_to_le_uint(bit.band(ngx.worker.pid(), 0xFFFF), 2)
 
 local inc = 0
 local function generate_id ( )


### PR DESCRIPTION
Use ngx.worker.pid() instead of ngx.var.pid in object_id.lua. This
is both more efficient and allows caching of the module during
worker init, rather than performing the require during request
processing.

Relevant lua module documentation:
https://www.nginx.com/resources/wiki/modules/lua/#ngx-worker-pid